### PR TITLE
Monitor tweaks

### DIFF
--- a/pentagon_datadog/monitors/kubernetes/cluster_bytes_received.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_bytes_received.yml
@@ -17,5 +17,5 @@ message: |
   {{/is_alert_recovery}}
   ${notifications}
 type: metric alert
-thresholds: {critical: 20000, warning: 15000}
+thresholds: {critical: 20000000, warning: 17500000}
 timeout_h: 0

--- a/pentagon_datadog/monitors/kubernetes/cluster_bytes_received.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_bytes_received.yml
@@ -10,7 +10,7 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_15m):avg:kubernetes.network.rx_bytes{kubernetescluster:${cluster}} by {host} > 20000
+query: avg(last_15m):avg:kubernetes.network.rx_bytes{kubernetescluster:${cluster}} by {host} > 20000000
 message: |
   {{#is_alert_recovery}}
   Increase in network bytes in

--- a/pentagon_datadog/monitors/kubernetes/cluster_bytes_sent.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_bytes_sent.yml
@@ -17,5 +17,5 @@ message: |
   {{/is_alert_recovery}}
   ${notifications}
 type: metric alert
-thresholds: {critical: 20000, warning: 15000}
+thresholds: {critical: 20000000, warning: 17500000}
 timeout_h: 0

--- a/pentagon_datadog/monitors/kubernetes/cluster_bytes_sent.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_bytes_sent.yml
@@ -10,7 +10,7 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_15m):avg:kubernetes.network.tx_bytes{kubernetescluster:${cluster}} by {host} > 20000
+query: avg(last_15m):avg:kubernetes.network.tx_bytes{kubernetescluster:${cluster}} by {host} > 20000000
 message: |
   {{#is_alert_recovery}}
   Increase in network bytes out

--- a/pentagon_datadog/monitors/kubernetes/cluster_disk_usage_high.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_disk_usage_high.yml
@@ -10,13 +10,13 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_15m):( avg:system.disk.total{kubernetescluster:${cluster}} by {host} - avg:system.disk.free{iam_profile:nodes.${cluster}} by {host} ) / avg:system.disk.total{kubernetescluster:${cluster}} by {host} * 100 > 90
+query: avg(last_15m):( avg:system.disk.total{kubernetescluster:${cluster}} by {host} - avg:system.disk.free{kubernetescluster:${cluster}} by {host} ) / avg:system.disk.total{kubernetescluster:${cluster}} by {host} * 100 > 90
 message: |
     {{#is_alert}}
     Disk Usage has been above threshold over 15 minutes on {{host.name}}
     {{/is_alert}}
     {{#is_warning}}
-    Disk Usage has been above threshold over 15 minutes on {{host.name}} 
+    Disk Usage has been above threshold over 15 minutes on {{host.name}}
     {{/is_warning}}
     {{^is_alert}}
     Disk Usage has recovered on {{host.name}}

--- a/pentagon_datadog/monitors/kubernetes/cluster_iops.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_iops.yml
@@ -10,12 +10,12 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_1h):avg:aws.ebs.volume_read_ops{kubernetescluster:${cluster}} by {host} + avg:aws.ebs.volume_write_ops{kubernetescluster:${cluster}} by {host} > 20000
+query: avg(last_1h):avg:aws.ebs.volume_read_ops{kubernetescluster:${cluster}} by {host} + avg:aws.ebs.volume_write_ops{kubernetescluster:${cluster}} by {host} > 3400
 message: |
   {{#is_alert}}
   {{host.name}} has as increasing number of disk operations
   {{/is_alert}}
   ${notifications}
 type: query alert
-thresholds: {critical: 20000, warning: 15000}
+thresholds: {critical: 3400, warning: 3200}
 timeout_h: 0


### PR DESCRIPTION
Increases default network RX/TX threshold values; decreases default cluster EBS IOPS thresholds; changes cluster disk usage query to use only the `kubernetescluster` tag for all parts of its query. 