### PR TITLE
Better 5xx alert

### DIFF
--- a/pentagon_datadog/monitors/kubernetes/elb_error_rate.yml
+++ b/pentagon_datadog/monitors/kubernetes/elb_error_rate.yml
@@ -1,6 +1,6 @@
 notify_audit: false
 locked: false
-name: '[${environment}] API Application ELB returning high number of 5xx errors'
+name: '[${environment}] ELB returning high number of 5xx errors'
 tags: ['${environment}', reactiveops]
 include_tags: false
 no_data_timeframe: null
@@ -10,13 +10,10 @@ new_host_delay: 300
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: min(last_1h):sum:aws.elb.httpcode_backend_5xx{*}.as_rate() >= 2
+query: "min(last_15m):100 * avg:aws.elb.httpcode_backend_5xx{kubernetescluster:${cluster}} by {loadbalancername}.as_rate().fill(zero) / avg:aws.elb.request_count{kubernetescluster:${cluster}} by {loadbalancername}.as_rate().fill(zero) >= 2"
 message: |
   {{#is_alert}}
-  The ELB is returning a higher than normal number of 5xx
-  errors
-  - Is AWS having another WAF outage
-  - Are healthy hosts available behind ALB (target group)
+  The {{kubernetes.io/service-name}} ELB is reporting the Kubernetes Service is returning more 5xx errors than normal
   {{/is_alert}}
   {{^is_alert}}
   The ELB is no longer returning 5xx errors


### PR DESCRIPTION
 Better 5xx alert that fails for consistent 5xx failures from env-specific cluster ELBs. Also removed client-specific messages about ALBs.