### PR TITLE
Add kube-system crash monitor

### DIFF
--- a/pentagon_datadog/monitors/kubernetes/kubesystem_crashes.yml
+++ b/pentagon_datadog/monitors/kubernetes/kubesystem_crashes.yml
@@ -1,0 +1,24 @@
+notify_audit: false
+locked: false
+name: '[${environment}] Increased kube-system crashes'
+tags: ['${environment}', reactiveops]
+include_tags: true
+no_data_timeframe: null
+silenced: {}
+new_host_delay: 300
+require_full_window: false
+notify_no_data: false
+renotify_interval: 0
+escalation_message: ''
+query: avg(last_5m):sum:kubernetes_state.container.restarts{kubernetescluster:${cluster},namespace:kube-system} by {pod} - hour_before(sum:kubernetes_state.container.restarts{kubernetescluster:${cluster},namespace:kube-system} by {pod}) > 1
+message: |
+  {{#is_alert}}
+  {{pod.name}} has crashed repeatedly over the last hour
+  {{/is_alert}}
+  {{^is_alert}}
+  {{pod.name}} appears to have stopped crashing
+  {{/is_alert}}
+  ${notifications}
+type: query alert
+thresholds: {critical: 1}
+timeout_h: 0


### PR DESCRIPTION
Alerts if there is more than 1 crash in the last hour. Because the metric we get is the current total crash count, I had to be creative in calculating the difference. I started by using the `diff()` in Datadog, but that would only show me either 0 or 1 (occasionally 2 at the very beginning of a fast crash loop) because of the backoff. Instead this time shifts and diffs to an hour ago so any 2 crashes in a 1 hour window will trigger this.

We could theoretically also create a check for infrequent crashes as well so we don't miss a crash that happens less frequently than every hour.

Also good to note that this is for anything in `kube-system` which enforces the idea that kube-system is for cluster-critical apps, but also potentially skips out on other important namespaces without specific action.