### PR TITLE
Add logging alerts and jinja-templated values feature

### DIFF
--- a/pentagon_datadog/monitors/logging/logging_limits.yml
+++ b/pentagon_datadog/monitors/logging/logging_limits.yml
@@ -1,0 +1,26 @@
+notify_audit: false
+locked: false
+name: 'Log rate is high'
+tags: [reactiveops]
+include_tags: false
+no_data_timeframe: null
+silenced: {}
+new_host_delay: 300
+require_full_window: true
+notify_no_data: false
+renotify_interval: 0
+escalation_message: ''
+query: Jinja:logs("*").index("main").rollup("count").last("1d") > {{(monthly_log_max | int) // 31}}
+message: |
+  {{#is_alert}}
+  Logging rates over the last day have been very high. At this rate, the total logs for this month might exceed the plan for ${monthly_log_max}
+  {{/is_alert}}
+  {{^is_alert}}
+  The logging rate has returned to normal
+  {{/is_alert}}
+  ${notifications}
+type: log alert
+thresholds:
+  critical: Jinja:{{(monthly_log_max | int) // 31}}
+  warning: Jinja:{{(monthly_log_max | int) * 9 // 310}}
+timeout_h: 0

--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,16 @@ setup(name='pentagon_datadog',
       license='Apache2.0',
       include_package_data=True,
       install_requires=[
-          'oyaml>=0.4'
+          'oyaml>=0.4',
+          'Jinja2'
           ],
       data_files=[],
       package_data={
         "pentagon_datadog": [
           'files/*',
-          'monitors/kubernetes/*',
           'monitors/elasticsearch/*',
+          'monitors/kubernetes/*',
+          'monitors/logging/*',
           'monitors/node/*',
           'monitors/rds/*',
           'dashboards/kubernetes/*'


### PR DESCRIPTION
I went to add a monitor for alerting if the logging rate was high enough to worry about breaking billing limits. To really get it right, we need to know what the billing limit is (because the alert is absolute and not relative). To do that, I realized we'd need to be able to template a little (so we can say "the rate for the last day is more than 1/31 of the monthly limit") which would require a little math when generating the TF.

To be able to do math (and potentially other kewl things in the future), I added an option to specify Jinja templates as the value for a monitor setting. If your value in the monitor yaml spec starts with `Jinja` we roll it render it using jinja and the `definitions` for values.

Incidentally, I cleaned up `_replace_definitions` so that it recursively handles lists and dicts instead of special-casing `tags`, removed a duplicate definition of `global_definitions`, and removed some unused imports.