### PR TITLE
Adjusting IOPS monitor

### DIFF
--- a/pentagon_datadog/monitors/kubernetes/cluster_iops.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_iops.yml
@@ -10,7 +10,7 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_1h):avg:aws.ebs.volume_read_ops{kubernetescluster:${cluster}} by {host} + avg:aws.ebs.volume_write_ops{kubernetescluster:${cluster}} by {host} > 3400
+query: avg(last_1h):avg:aws.ebs.volume_read_ops{kubernetescluster:${cluster}} by {host} + avg:aws.ebs.volume_write_ops{kubernetescluster:${cluster}} by {host} > 900000
 message: |
   {{#is_alert}}
   {{host.name}} has as increasing number of disk operations


### PR DESCRIPTION
This accounts for how Datadog actually aggregates IOPS data points from Cloudwatch -- it adds all IOPS datapoints from the last 5 minutes into a single datapoint in Datadog. 