### PR TITLE
Calculate ratio to total ops in gcp disk throttle monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1]
+### updated
+- updated gcp.disk_throttled_read|write_ops monitors to monitor the percentage of throttle disk ops.
+
 ## [1.0.0]
 ### Updated
 - GCP and AWS specific monitors separated out into their own directories

--- a/pentagon_datadog/monitors/gcp/disk_throttled_read_ops.yml
+++ b/pentagon_datadog/monitors/gcp/disk_throttled_read_ops.yml
@@ -5,13 +5,13 @@ tags: ['${environment}', reactiveops]
 include_tags: false
 no_data_timeframe: null
 silenced: {}
-new_host_delay: 300
-require_full_window: false
+new_host_delay: 600
+require_full_window: true
 notify_no_data: false
 renotify_interval: 0
+evaluation_delay: 60
 escalation_message: ''
-query: max(last_1h):max:gcp.gce.instance.disk.throttled_read_ops_count{kubernetescluster:${cluster},kubernetescluster:${cluster}}
-  by {host} >= 1
+query: min(last_2h):(avg:gcp.gce.instance.disk.throttled_read_ops_count{kubernetescluster:${cluster}} by {host}.rollup(avg, 300) / avg:gcp.gce.instance.disk.read_ops_count{kubernetescluster:${cluster}} by {host}.rollup(avg, 300) ) * 100 > 20
 message: |
   This metric indicates disk reads are being throttled. This can result in
     - timeouts during image pulls
@@ -20,5 +20,5 @@ message: |
   Are one or more pods using more disk read ops than expected?
   ${notifications}
 type: query alert
-thresholds: {critical: 1, critical_recovery: 0}
+thresholds: {critical: 30, warning: 20, critical_recovery: 15}
 timeout_h: 0

--- a/pentagon_datadog/monitors/gcp/disk_throttled_write_ops.yml
+++ b/pentagon_datadog/monitors/gcp/disk_throttled_write_ops.yml
@@ -5,13 +5,13 @@ tags: ['${environment}', reactiveops]
 include_tags: false
 no_data_timeframe: null
 silenced: {}
-new_host_delay: 300
-require_full_window: false
+new_host_delay: 600
+require_full_window: true
 notify_no_data: false
 renotify_interval: 0
+evaluation_delay: 60
 escalation_message: ''
-query: max(last_1h):max:gcp.gce.instance.disk.throttled_write_ops_count{kubernetescluster:${cluster},kubernetescluster:${cluster}}
-  by {host} >= 1
+query: min(last_2h):(avg:gcp.gce.instance.disk.throttled_write_ops_count{kubernetescluster:${cluster}} by {host}.rollup(avg, 300) / avg:gcp.gce.instance.disk.write_ops_count{kubernetescluster:${cluster}} by {host}.rollup(avg, 300) ) * 100 > 20
 message: |
   This metric indicates disk writes are being throttled. This can result in
     - timeouts during image pulls
@@ -19,5 +19,5 @@ message: |
   Are one or more pods using more disk write ops than expected?
   ${notifications}
 type: query alert
-thresholds: {critical: 1, critical_recovery: 0}
+thresholds: {critical: 30, warning: 20, critical_recovery: 15}
 timeout_h: 0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
     sys.exit(1)
 
 setup(name='pentagon_datadog',
-      version='1.0.0',
+      version='1.0.1',
       description='Pentagon Component to install common datadog monitors',
       author='ReactiveOp Inc.',
       author_email='reactive@reactiveops.com',


### PR DESCRIPTION
I edited the gcp disk throttle monitors to calculate the ratio of throttled ops to total ops.  When doing this I discovered the two metrics reporting timeframe intervals are sometimes slightly skewed in datadog so I'm calculating a rolling average.  I adjusted the thresholds to match the new query.