### PR TITLE
[WIP] Add support for multi-namespace monitors

### DIFF
--- a/pentagon_datadog/monitor.py
+++ b/pentagon_datadog/monitor.py
@@ -38,7 +38,8 @@ class Monitors(Rodd):
                 m = Monitor(monitor)
                 m._exceptions = exceptions
                 m._global_definitions = global_definitions
-                m.add(destination, overwrite=True)
+                m.add()
+            m.generate_resource_tf(destination, overwrite=True)
             self._validate_tf(destination)
         except TypeError, e:
             logging.debug(e)

--- a/pentagon_datadog/monitors/kubernetes/deploy_replica_alert.yml
+++ b/pentagon_datadog/monitors/kubernetes/deploy_replica_alert.yml
@@ -1,7 +1,8 @@
 notify_audit: false
 locked: false
-name: '[${environment}] Deployment replica alert'
+name: '[${environment}] Deployment replica alert ${namespace}'
 tags: ['${environment}', reactiveops]
+namespaced: true
 include_tags: true
 no_data_timeframe: null
 silenced: {}

--- a/pentagon_datadog/rodd.py
+++ b/pentagon_datadog/rodd.py
@@ -90,7 +90,16 @@ class Rodd(ComponentBase):
 
                 logging.debug('Final context: {}'.format(data))
 
-                self._create_tf_file(data)
+                # If namespace is a list, create a separate tf file per namespace
+                definitions = data.get('definitions', {})
+                if isinstance(definitions.get('namespace'), list):
+                    for namespace in definitions.get('namespace', []):
+                        data_copy = data.copy()
+                        data_copy['definitions']['namespace'] = namespace
+                        data_copy['name'] = '{} {}'.format(data.get('name'), namespace)
+                        self._create_tf_file(data_copy)
+                else:
+                    self._create_tf_file(data)
 
     def _create_tf_file(self, data):
         try:


### PR DESCRIPTION
I dug in to see where we could add multi-namespace support for monitors. I wasn't totally happy with where it ended up in the abstractions but this does generate separate monitors for namespaces.

I'm missing one thing to get this fully working. I want to be able to have multi-namespace monitors without also creating the global monitor.

Monitor customization (ie including both `kubernetes` and `kubernetes.some_specific_monitor` with overrides in the same rodd yaml) relies on overwriting the generated files. The first instance of the monitor writes out a file then the second overwrites that file applying the customization. Since this PR approach writes out a file per namespace there's no clean way to avoid writing out the first global namespace monitor from the `kubernetes` group. 

I'll keep working on this to find a way to prevent the global monitor.

Resolves #37 