### PR TITLE
increase high disk utilization timewindow from 15m to 30m

### DIFF
--- a/pentagon_datadog/monitors/kubernetes/cluster_disk_usage_high.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_disk_usage_high.yml
@@ -10,13 +10,13 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_15m):( avg:system.disk.total{kubernetescluster:${cluster}} by {host} - avg:system.disk.free{kubernetescluster:${cluster}} by {host} ) / avg:system.disk.total{kubernetescluster:${cluster}} by {host} * 100 > ${cluster_disk_usage_high_critical_threshold}
+query: avg(last_30m):( avg:system.disk.total{kubernetescluster:${cluster}} by {host} - avg:system.disk.free{kubernetescluster:${cluster}} by {host} ) / avg:system.disk.total{kubernetescluster:${cluster}} by {host} * 100 > ${cluster_disk_usage_high_critical_threshold}
 message: |
     {{#is_alert}}
-    Disk Usage has been above threshold over 15 minutes on {{host.name}}
+    Disk Usage has been above threshold over 30 minutes on {{host.name}}
     {{/is_alert}}
     {{#is_warning}}
-    Disk Usage has been above threshold over 15 minutes on {{host.name}}
+    Disk Usage has been above threshold over 30 minutes on {{host.name}}
     {{/is_warning}}
     {{^is_alert}}
     Disk Usage has recovered on {{host.name}}


### PR DESCRIPTION
Increases the window from 15 minutes to 30 minutes for the high disk utilization alert. 15 minutes seems like it might be too sensitive in production usage -- we've seen this resolve itself shortly after 15 minutes. 