### PR TITLE
Multi-namespace monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Updated
 
 - Resource override functionality reworked to remove reliance on multiple file writes.
+- Deploy replica and pod crash monitors to support multiple namespaces.
 
 ## [1.10.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.11.0]
+
+### Added
+
+- Support for namespaced monitors.
+
+### Updated
+
+- Resource override functionality reworked to remove reliance on multiple file writes.
+
 ## [1.10.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ definitions:
 monitors:
   - source: kubernetes.deploy_replica_alert
     definitions:
-      namespace: ['kube-system', 'infra', 'tiller']
+      namespace: ['infra', 'kube-system', 'rbac-manager']
 ```
 
 #### Exceptions

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ monitors:
       environment: staging # this will override the global value
 ```
 
+#### Namespaced Monitors
+
+Datadog does not support multiple namespaces in monitor query filters. As a workaround, Rodd monitors that include a namespace filter can generate multiple namespace specific monitors from a single monitor definition.
+
+The underlying Rodd monitor must have `vary_by_namespace: true` set. The monitor's namespace definition value can be a string or a list. Each namespace definition value will produce a separate monitor and Terraform file.
+
+```yaml
+definitions:
+  cluster: working.cluster
+  environment: production
+monitors:
+  - source: kubernetes.deploy_replica_alert
+    definitions:
+      namespace: ['kube-system', 'infra', 'tiller']
+```
+
 #### Exceptions
 Sometimes you'll want to apply all the monitors or dashboards in a family of except one or two. In this case, you can can use a list of `exceptions` at the root of the YAML document. All the monitors or dashboards in that family will be templated except the ones listed in `exceptions`. The full path of the monitor is required:
 

--- a/docs/monitors.md
+++ b/docs/monitors.md
@@ -219,6 +219,7 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `namespace`
         * Optional Definitions:
             * `deploy_replica_alert_critical_threshold`: 0
     * [High Node IO Wait Time](/pentagon_datadog/monitors/kubernetes/high_node_io_wait_time.yml)
@@ -284,4 +285,3 @@
             * `environment`
             * `notifications`
         * Optional Definitions: n/a
-

--- a/pentagon_datadog/__init__.py
+++ b/pentagon_datadog/__init__.py
@@ -16,9 +16,9 @@
 import os
 import logging
 from pentagon.component import ComponentBase
-from monitor import Monitor, Monitors
-from dashboard import Dashboard, Dashboards
-from downtime import Downtime, Downtimes
+from monitor import Monitors
+from dashboard import Dashboards
+from downtime import Downtimes
 
 
 class Datadog(ComponentBase):
@@ -29,3 +29,4 @@ class Datadog(ComponentBase):
         super(Datadog, self).add(destination, overwrite=True)
         os.remove("{}/monitor.tf".format(self._destination_directory_name))
         os.remove("{}/dashboard.tf".format(self._destination_directory_name))
+        os.remove("{}/downtime.tf".format(self._destination_directory_name))

--- a/pentagon_datadog/dashboard.py
+++ b/pentagon_datadog/dashboard.py
@@ -18,23 +18,11 @@ import logging
 from pentagon_datadog.rodd import Rodd
 
 
-class Dashboard(Rodd):
-    template_file_name = 'dashboard.tf.jinja'
-    _item_type = 'dashboards'
-
-
 class Dashboards(Rodd):
 
     def add(self, destination, overwrite=False):
-        logging.debug("Adding dashboard .tf files")
-        global_definitions = self._data.get('definitions', {})
-        try:
-            for dash in self._data.get('dashboards'):
-                logging.debug(dash)
-                d = Dashboard(dash)
-                d._global_definitions = global_definitions
-                d.add(destination, overwrite=True)
-            self._validate_tf(destination)
-        except TypeError, e:
-            logging.debug(e)
-            logging.error("No dashboards declared or no file argument passed.")
+        self.template_file_name = 'dashboard.tf.jinja'
+        self._item_type = 'dashboards'
+        logging.debug("Generating dashboard .tf files")
+        Rodd.add(self, destination, overwrite=True)
+        self._validate_tf(destination)

--- a/pentagon_datadog/downtime.py
+++ b/pentagon_datadog/downtime.py
@@ -14,27 +14,15 @@
 # limitations under the License.
 
 import logging
-import traceback
 
 from pentagon_datadog.rodd import Rodd
 
-class Downtime(Rodd):
-    template_file_name = 'downtime.tf.jinja'
-    _item_type = 'downtime'
 
 class Downtimes(Rodd):
-    def add(self, destination, overwrite=False):
-        logging.debug("Adding downtime .tf files")
-        global_definitions = self._data.get('definitions', {})
-        downtimes = self._data.get('downtimes', {})
 
-        try:
-            for downtime in downtimes:
-                logging.debug(downtime)
-                d = Downtime(downtime)
-                d._global_definitions = global_definitions
-                d.add(destination, overwrite=True)
-            self._validate_tf(destination)
-        except TypeError, e:
-            logging.debug(e)
-            logging.debug(traceback.format_exc())
+    def add(self, destination, overwrite=False):
+        self.template_file_name = 'downtime.tf.jinja'
+        self._item_type = 'downtimes'
+        logging.debug("Generating downtime .tf files")
+        Rodd.add(self, destination, overwrite=True)
+        self._validate_tf(destination)

--- a/pentagon_datadog/files/datadog/rodd-example.yaml
+++ b/pentagon_datadog/files/datadog/rodd-example.yaml
@@ -7,6 +7,9 @@ dashboards:
   - source: kubernetes.resources
 monitors:
   - source: kubernetes
+  - source: kubernetes.deploy_replica_alert
+    definitions:
+      namespace: ['infra', 'kube-system', 'rbac-manager']
 downtimes:
   - name: Weekly Maintenance Window
     scope: "*"

--- a/pentagon_datadog/monitor.py
+++ b/pentagon_datadog/monitor.py
@@ -14,33 +14,15 @@
 # limitations under the License.
 
 import logging
-import traceback
 
 from pentagon_datadog.rodd import Rodd
-
-
-class Monitor(Rodd):
-    template_file_name = 'monitor.tf.jinja'
-    _item_type = 'monitors'
 
 
 class Monitors(Rodd):
 
     def add(self, destination, overwrite=False):
-        logging.debug("Adding monitor .tf files")
-        global_definitions = self._data.get('definitions', {})
-        monitors = self._data.get('monitors', {})
-        exceptions = self._data.get('exceptions', [])
-
-        try:
-            for monitor in monitors:
-                logging.debug(monitor)
-                m = Monitor(monitor)
-                m._exceptions = exceptions
-                m._global_definitions = global_definitions
-                m.add(destination, overwrite=True)
-            self._validate_tf(destination)
-        except TypeError, e:
-            logging.debug(e)
-            logging.debug(traceback.format_exc())
-            logging.error("No monitors declared or no file argument passed.")
+        self.template_file_name = 'monitor.tf.jinja'
+        self._item_type = 'monitors'
+        logging.debug("Generating monitor .tf files")
+        Rodd.add(self, destination, overwrite=True)
+        self._validate_tf(destination)

--- a/pentagon_datadog/monitors/kubernetes/deploy_replica_alert.yml
+++ b/pentagon_datadog/monitors/kubernetes/deploy_replica_alert.yml
@@ -1,6 +1,6 @@
 notify_audit: false
 locked: false
-name: '[${environment}] Deployment replica alert'
+name: '[${environment}] Deployment replica alert ${namespace}'
 tags: ['${environment}', reactiveops]
 include_tags: true
 no_data_timeframe: null
@@ -10,6 +10,7 @@ require_full_window: false
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
+vary_by_namespace: true
 query: max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:${cluster},namespace:${namespace}} by {deployment} <= ${deploy_replica_alert_critical_threshold}
 message: |
   {{#is_alert}}

--- a/pentagon_datadog/monitors/kubernetes/deploy_replica_alert.yml
+++ b/pentagon_datadog/monitors/kubernetes/deploy_replica_alert.yml
@@ -26,3 +26,4 @@ thresholds:
 timeout_h: 0
 definition_defaults:
   deploy_replica_alert_critical_threshold: 0
+  namespace: kube-system

--- a/pentagon_datadog/monitors/kubernetes/pod_crashes.yml
+++ b/pentagon_datadog/monitors/kubernetes/pod_crashes.yml
@@ -1,6 +1,6 @@
 notify_audit: false
 locked: false
-name: '[${environment}] Increased kube-system crashes'
+name: '[${environment}] Increased pod crashes ${namespace}'
 tags: ['${environment}', reactiveops]
 include_tags: true
 no_data_timeframe: null
@@ -10,7 +10,8 @@ require_full_window: false
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_5m):avg:kubernetes_state.container.restarts{kubernetescluster:${cluster},namespace:kube-system} by {pod} - hour_before(avg:kubernetes_state.container.restarts{kubernetescluster:${cluster},namespace:kube-system} by {pod}) > ${kubesystem_crashes_critical_threshold}
+vary_by_namespace: true
+query: avg(last_5m):avg:kubernetes_state.container.restarts{kubernetescluster:${cluster},namespace:${namespace}} by {pod} - hour_before(avg:kubernetes_state.container.restarts{kubernetescluster:${cluster},namespace:${namespace}} by {pod}) > ${kubesystem_crashes_critical_threshold}
 message: |
   {{#is_alert}}
   {{pod.name}} has crashed repeatedly over the last hour
@@ -25,3 +26,4 @@ thresholds:
 timeout_h: 0
 definition_defaults:
   kubesystem_crashes_critical_threshold: 1
+  namespace: kube-system

--- a/pentagon_datadog/rodd.py
+++ b/pentagon_datadog/rodd.py
@@ -82,9 +82,10 @@ class Rodd(ComponentBase):
 
                 for local_source_path in item_local_paths:
                     resource_data = {}
-                    resource_id = '.'.join((local_source_path.split('.')[0]).split('/')[-3:])
+                    resource_id = '/'.join(local_source_path.split('/')[-3:])
                     logging.debug("Loading {}".format(local_source_path))
                     logging.debug("Source is: {} ".format(source))
+                    logging.debug("Resource id is: {} ".format(resource_id))
 
                     if os.path.isfile(local_source_path) and ('/').join(local_source_path.split('/')[-2:]) in self.exceptions:
                         continue

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
     sys.exit(1)
 
 setup(name='pentagon_datadog',
-      version='1.10.2',
+      version='1.11.0',
       description='Pentagon Component to install common datadog monitors',
       author='ReactiveOp Inc.',
       author_email='reactive@reactiveops.com',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -54,6 +54,7 @@ class TestMonitors(unittest.TestCase):
     test_input_file = "test/files/test_input.yml"
 
     def setUp(self):
+        self.deploy_replica_alert_namespaces = ['one', 'two', 'three']
         with open(self.test_input_file) as f:
             self._data = yaml.load(f.read())
         ms = Monitors(self._data)
@@ -77,9 +78,21 @@ class TestMonitors(unittest.TestCase):
 
         self.assertEqual(gold, new)
 
+    def test_deployment_replica_alert(self):
+        for namespace in self.deploy_replica_alert_namespaces:
+            gold = hashlib.md5(open("test/files/test_deployment_replica_alert_{}.tf".format(namespace)).read()).hexdigest()
+            new = hashlib.md5(open("test_deployment_replica_alert_{}.tf".format(namespace)).read()).hexdigest()
+
+            logging.debug(gold)
+            logging.debug(new)
+
+            self.assertEqual(gold, new)
+
     def tearDown(self):
         os.remove("test_pods_are_stuck_pending.tf")
         os.remove("test_increase_in_network_errors.tf")
+        for namespace in self.deploy_replica_alert_namespaces:
+            os.remove("test_deployment_replica_alert_{}.tf".format(namespace))
 
 
 class TestDowntimes(unittest.TestCase):

--- a/test/files/test_deployment_replica_alert_one.tf
+++ b/test/files/test_deployment_replica_alert_one.tf
@@ -1,0 +1,29 @@
+resource "datadog_monitor" "test_deployment_replica_alert_one" {
+  # Required Arguments
+  name = "[test] Deployment replica alert one"
+  type = "query alert"
+
+  message = <<EOF
+  {{#is_alert}}
+Available replicas is currently 0 for {{deployment.name}}
+{{/is_alert}}
+{{^is_alert}}
+Available replicas is no longer 0 for {{deployment.name}}
+{{/is_alert}}
+${notifications}
+
+  EOF
+
+  query = "max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:cluster_name,namespace:one} by {deployment} <= 0"
+
+  # Optional Arguments
+  new_host_delay = 300
+
+  thresholds {
+    critical = 0
+  }
+
+  include_tags = true
+  tags         = ["test", "reactiveops"]
+  silenced     = {}
+}

--- a/test/files/test_deployment_replica_alert_three.tf
+++ b/test/files/test_deployment_replica_alert_three.tf
@@ -1,0 +1,29 @@
+resource "datadog_monitor" "test_deployment_replica_alert_three" {
+  # Required Arguments
+  name = "[test] Deployment replica alert three"
+  type = "query alert"
+
+  message = <<EOF
+  {{#is_alert}}
+Available replicas is currently 0 for {{deployment.name}}
+{{/is_alert}}
+{{^is_alert}}
+Available replicas is no longer 0 for {{deployment.name}}
+{{/is_alert}}
+${notifications}
+
+  EOF
+
+  query = "max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:cluster_name,namespace:three} by {deployment} <= 0"
+
+  # Optional Arguments
+  new_host_delay = 300
+
+  thresholds {
+    critical = 0
+  }
+
+  include_tags = true
+  tags         = ["test", "reactiveops"]
+  silenced     = {}
+}

--- a/test/files/test_deployment_replica_alert_two.tf
+++ b/test/files/test_deployment_replica_alert_two.tf
@@ -1,0 +1,29 @@
+resource "datadog_monitor" "test_deployment_replica_alert_two" {
+  # Required Arguments
+  name = "[test] Deployment replica alert two"
+  type = "query alert"
+
+  message = <<EOF
+  {{#is_alert}}
+Available replicas is currently 0 for {{deployment.name}}
+{{/is_alert}}
+{{^is_alert}}
+Available replicas is no longer 0 for {{deployment.name}}
+{{/is_alert}}
+${notifications}
+
+  EOF
+
+  query = "max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:cluster_name,namespace:two} by {deployment} <= 0"
+
+  # Optional Arguments
+  new_host_delay = 300
+
+  thresholds {
+    critical = 0
+  }
+
+  include_tags = true
+  tags         = ["test", "reactiveops"]
+  silenced     = {}
+}

--- a/test/files/test_input.yml
+++ b/test/files/test_input.yml
@@ -11,6 +11,9 @@ monitors:
     definitions:
       cluster_network_errors_critical_threshold: 10
       cluster_network_errors_warning_threshold: 5
+  - source: kubernetes.deploy_replica_alert
+    definitions:
+      namespace: ['one','two','three']
 downtimes:
   - name: Test Maintenance Window
     scope: "*"


### PR DESCRIPTION
This adds support for creating multiple monitors from a single definition for a list of namespaces.

The underlying Rodd monitor must have `vary_by_namespace: true` set. The monitor's namespace definition value can be a string or a list. Each namespace definition value will produce a separate monitor and Terraform file.

I had to reorganize the Rodd classes to get this working. Now the Pentagon component builds up a collection of monitors, applies overrides in sequential order, and then writes out the results to TF files.

Resolves #37 