### PR TITLE
Fix definition precendence (top to least)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.11.1]
+
+### Fixed
+
+* Order of definition precedence fixed (most to least): monitor, global, monitor default
+
 ## [1.11.0]
 
 ### Added

--- a/pentagon_datadog/rodd.py
+++ b/pentagon_datadog/rodd.py
@@ -199,7 +199,7 @@ class Rodd(ComponentBase):
 
     def definitions(self, data):
         """ Return dictionary of merged definitions: global, definition_defaults, definitions """
-        definitions = merge_dict(self._global_definitions.copy(), data.get('definition_defaults', {}), clobber=True)
+        definitions = merge_dict(data.get('definition_defaults', {}), self._global_definitions.copy(), clobber=True)
         definitions = merge_dict(definitions, data.get('definitions', {}), clobber=True)
         return definitions
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
     sys.exit(1)
 
 setup(name='pentagon_datadog',
-      version='1.11.1',
+      version='1.12.0',
       description='Pentagon Component to install common datadog monitors',
       author='ReactiveOp Inc.',
       author_email='reactive@reactiveops.com',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
     sys.exit(1)
 
 setup(name='pentagon_datadog',
-      version='1.11.0',
+      version='1.11.1',
       description='Pentagon Component to install common datadog monitors',
       author='ReactiveOp Inc.',
       author_email='reactive@reactiveops.com',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -49,6 +49,30 @@ class TestDashboards(unittest.TestCase):
         os.remove("reactiveops_kubernetes_resource_timeboard.tf")
 
 
+class TestMonitorDefinitionsGlobal(unittest.TestCase):
+    name = "test-monitors"
+    test_input_file = "test/files/test_input.yml"
+
+    def setUp(self):
+        with open(self.test_input_file) as f:
+            self._data = yaml.load(f.read())
+            self._data['definitions']['pods_pending_critical_threshold'] = 1234
+        ms = Monitors(self._data)
+        ms.add("./", overwrite=True)
+
+    def test_pods_monitor_output(self):
+        gold = hashlib.md5(open("test/files/test_pods_are_stuck_pending_def_global.tf").read()).hexdigest()
+        new = hashlib.md5(open("test_pods_are_stuck_pending.tf").read()).hexdigest()
+
+        logging.debug(gold)
+        logging.debug(new)
+
+        self.assertEqual(gold, new)
+
+    def tearDown(self):
+        os.remove("test_pods_are_stuck_pending.tf")
+
+
 class TestMonitors(unittest.TestCase):
     name = "test-monitors"
     test_input_file = "test/files/test_input.yml"

--- a/test/files/test_pods_are_stuck_pending_def_global.tf
+++ b/test/files/test_pods_are_stuck_pending_def_global.tf
@@ -1,0 +1,33 @@
+resource "datadog_monitor" "test_pods_are_stuck_pending" {
+  # Required Arguments
+  name = "[test] Pods are stuck Pending"
+  type = "metric alert"
+
+  message = <<EOF
+  {{#is_alert}}
+There has been at least 1 pod Pending for 30 minutes.
+There are currently {{value}} pods Pending.
+  - Is something crash-looping?
+  - Is autoscaling adding node capacity where needed?
+  - Is a secret or a configmap missing?
+{{/is_alert}}
+{{^is_alert}}
+Pods are no longer pending.
+{{/is_alert}}
+${notifications}
+
+  EOF
+
+  query = "min(last_30m):sum:kubernetes_state.pod.status_phase{kubernetescluster:cluster_name,phase:running} - sum:kubernetes_state.pod.status_phase{kubernetescluster:cluster_name,phase:running} + sum:kubernetes_state.pod.status_phase{kubernetescluster:cluster_name,phase:pending}.fill(zero) >= 1234"
+
+  # Optional Arguments
+  new_host_delay = 300
+
+  thresholds {
+    critical = 1234
+  }
+
+  require_full_window = true
+  tags                = ["test", "reactiveops"]
+  silenced            = {}
+}


### PR DESCRIPTION
Recent change broke definition precedence. This puts it back to: monitor, global, monitor default