### PR TITLE
Add an hpa error monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.12.1]
+## [1.13.0]
 
 ### Added
 - hpa error monitor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.12.1]
+
+### Added
+- hpa error monitor
+
 ## [1.12.0]
 
 ### Updated

--- a/docs/monitors.md
+++ b/docs/monitors.md
@@ -51,117 +51,117 @@
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Firewall Quota](/pentagon_datadog/monitors/gcp-quotas/firewall_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Forwarding Rules Quota](/pentagon_datadog/monitors/gcp-quotas/forwarding_rules_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Health Checks Quota.yml](/pentagon_datadog/monitors/gcp-quotas/health_checks_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [HTTP Proxy Quota.yml](/pentagon_datadog/monitors/gcp-quotas/http_proxy_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [HTTPS Proxy Quota.yml](/pentagon_datadog/monitors/gcp-quotas/https_proxy_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Images Quota.yml](/pentagon_datadog/monitors/gcp-quotas/images_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Interconnects Quota](/pentagon_datadog/monitors/gcp-quotas/interconnects_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Internal Address Quota.yml](/pentagon_datadog/monitors/gcp-quotas/internal_address_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Network Quota](/pentagon_datadog/monitors/gcp-quotas/network_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Routers Quota](/pentagon_datadog/monitors/gcp-quotas/routers_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Routes Quota](/pentagon_datadog/monitors/gcp-quotas/routes_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Security Policy Rules Quota.yml](/pentagon_datadog/monitors/gcp-quotas/security_policy_rules_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Snapshots Quota](/pentagon_datadog/monitors/gcp-quotas/snapshots_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [SSL Certs Quota.yml](/pentagon_datadog/monitors/gcp-quotas/ssl_certs_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Static Address Region Quota](/pentagon_datadog/monitors/gcp-quotas/static_address_region_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Static Addresses Project Quota](/pentagon_datadog/monitors/gcp-quotas/static_addresses_project_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Subnetworks Quota](/pentagon_datadog/monitors/gcp-quotas/subnetworks_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Target Instances Quota](/pentagon_datadog/monitors/gcp-quotas/target_instances_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [Target Pools Quota](/pentagon_datadog/monitors/gcp-quotas/target_pools_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [URL Maps Quota](/pentagon_datadog/monitors/gcp-quotas/url_maps_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [VPN Gateway Quota](/pentagon_datadog/monitors/gcp-quotas/vpn_gateway_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
     * [VPN Tunnels Quota](/pentagon_datadog/monitors/gcp-quotas/vpn_tunnels_quota.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
-        * Optional Definitions: n/a 
+        * Optional Definitions: n/a
 
 * Kubernetes:
     * [Cluster Bytes Received](/pentagon_datadog/monitors/kubernetes/cluster_bytes_received.yml)
@@ -205,7 +205,7 @@
             * `cluster`
         * Optional Definitions:
             * `cluster_memory_critical_threshold`: 0.1
-            * `cluster_memory_critical_warning`: 0.15 
+            * `cluster_memory_critical_warning`: 0.15
     * [Cluster Network Errors](/pentagon_datadog/monitors/kubernetes/cluster_network_errors.yml)
         * Required Definitions:
             * `environment`
@@ -262,6 +262,13 @@
             * `cluster`
         * Optional Definitions:
             * `pods_pending_critical_threshold`: 1
+    * [HPA Errors](/pentagon_datadog/monitors/kubernetes/hpa_failure.yml)
+        * Required Definitions:
+            * `environment`
+            * `notifications`
+            * `cluster`
+        * Optional Definitions:
+            * `hpa_failure_critical_threshold`: 200
 
 * RDS:
     * [Burst IOPs](/pentagon_datadog/monitors/rds/burst_iops.yml)
@@ -284,4 +291,3 @@
             * `environment`
             * `notifications`
         * Optional Definitions: n/a
-

--- a/pentagon_datadog/monitors/kubernetes/hpa_failure.yml
+++ b/pentagon_datadog/monitors/kubernetes/hpa_failure.yml
@@ -18,7 +18,5 @@ message: |
   HPA Metric Retrieval Failure has recovered.
   {{/is_alert_recovery}}
   ${notifications}
-thresholds:
-  critical: ${hpa_failure_critical_threshold}
 definition_defaults:
   hpa_failure_critical_threshold: 200

--- a/pentagon_datadog/monitors/kubernetes/hpa_failure.yml
+++ b/pentagon_datadog/monitors/kubernetes/hpa_failure.yml
@@ -1,0 +1,24 @@
+notify_audit: false
+locked: false
+name: '[${environment}] Kubelet unhealthy'
+tags: ['${environment}', reactiveops]
+include_tags: false
+no_data_timeframe: 120
+silenced: {}
+require_full_window: true
+notify_no_data: false
+renotify_interval: 0
+type: event alert
+query: "events('sources:kubernetes priority:all tags:kubernetescluster:${cluster} \"unable to fetch metrics from resource metrics API:\"').by('hpa').rollup('count').last('1h') > ${hpa_failure_critical_threshold}"
+message: |
+  {{#is_alert}}
+  A high number of hpa failures (> {{threshold}} ) are occurring.  Can HPAs get metrics?
+  {{/is_alert}}
+  {{#is_alert_recovery}}
+  HPA Metric Retrieval Failure has recovered.
+  {{/is_alert_recovery}}
+  ${notifications}
+thresholds:
+  critical: ${hpa_failure_critical_threshold}
+definition_defaults:
+  hpa_failure_critical_threshold: 200

--- a/pentagon_datadog/monitors/kubernetes/hpa_failure.yml
+++ b/pentagon_datadog/monitors/kubernetes/hpa_failure.yml
@@ -1,6 +1,6 @@
 notify_audit: false
 locked: false
-name: '[${environment}] Kubelet unhealthy'
+name: '[${environment}] HPA Errors'
 tags: ['${environment}', reactiveops]
 include_tags: false
 no_data_timeframe: 120

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
     sys.exit(1)
 
 setup(name='pentagon_datadog',
-      version='1.12.1',
+      version='1.13.0',
       description='Pentagon Component to install common datadog monitors',
       author='ReactiveOp Inc.',
       author_email='reactive@reactiveops.com',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
     sys.exit(1)
 
 setup(name='pentagon_datadog',
-      version='1.12.0',
+      version='1.12.1',
       description='Pentagon Component to install common datadog monitors',
       author='ReactiveOp Inc.',
       author_email='reactive@reactiveops.com',


### PR DESCRIPTION
I added a monitor that looks for hpa error events.  When a high number of these are occurring it usually indicates a systemic problem with all HPAs.  

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + datadog_monitor.prod_hpa_errors
      id:                  <computed>
      evaluation_delay:    <computed>
      include_tags:        "true"
      message:             "{{#is_alert}}\nA high number of hpa failures (> {{threshold}} ) are occurring.  Can HPAs get metrics?\n{{/is_alert}}\n{{#is_alert_recovery}}\nHPA Metric Retrieval Failure has recovered.\n{{/is_alert_recovery}}\n@testtesttest"
      name:                "[prod] HPA Errors"
      new_host_delay:      "300"
      no_data_timeframe:   "120"
      notify_no_data:      "false"
      query:               "events('sources:kubernetes priority:all tags:kubernetescluster:foo.bar.baz \"unable to fetch metrics from resource metrics API:\"').by('hpa').rollup('count').last('1h') > 200"
      require_full_window: "true"
      tags.#:              "2"
      tags.0:              "prod"
      tags.1:              "reactiveops"
      thresholds.%:        "1"
      thresholds.critical: "200"
      type:                "event alert"


Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

datadog_monitor.prod_hpa_errors: Creating...
  evaluation_delay:    "" => "<computed>"
  include_tags:        "" => "true"
  message:             "" => "{{#is_alert}}\nA high number of hpa failures (> {{threshold}} ) are occurring.  Can HPAs get metrics?\n{{/is_alert}}\n{{#is_alert_recovery}}\nHPA Metric Retrieval Failure has recovered.\n{{/is_alert_recovery}}\n@testtesttest"
  name:                "" => "[prod] HPA Errors"
  new_host_delay:      "" => "300"
  no_data_timeframe:   "" => "120"
  notify_no_data:      "" => "false"
  query:               "" => "events('sources:kubernetes priority:all tags:kubernetescluster:foo.bar.baz \"unable to fetch metrics from resource metrics API:\"').by('hpa').rollup('count').last('1h') > 200"
  require_full_window: "" => "true"
  tags.#:              "0" => "2"
  tags.0:              "" => "prod"
  tags.1:              "" => "reactiveops"
  thresholds.%:        "0" => "1"
  thresholds.critical: "" => "200"
  type:                "" => "event alert"
datadog_monitor.prod_hpa_errors: Creation complete after 0s (ID: 8642499)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```