### PR TITLE
Fixing #63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## [1.13.1]
+### Fixed
+- fixed string type check for variable replacement in inline monitors
 
 ## [1.13.0]
 

--- a/pentagon_datadog/rodd.py
+++ b/pentagon_datadog/rodd.py
@@ -170,7 +170,7 @@ class Rodd(ComponentBase):
         """ Replace ${definitions} with their value """
 
         def _replace_definition(string, definitions):
-            if type(string) == str:
+            if type(string) in [unicode, str]:
                 for var, value in definitions.iteritems():
                     logging.debug("Replacing Definition: {}:{}".format(var, value))
                     string = string.replace("${%s}" % str(var), str(value))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
     sys.exit(1)
 
 setup(name='pentagon_datadog',
-      version='1.13.0',
+      version='1.13.1',
       description='Pentagon Component to install common datadog monitors',
       author='ReactiveOp Inc.',
       author_email='reactive@reactiveops.com',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -112,9 +112,20 @@ class TestMonitors(unittest.TestCase):
 
             self.assertEqual(gold, new)
 
+    def test_inline_definition_replacement(self):
+        for namespace in self.deploy_replica_alert_namespaces:
+            gold = hashlib.md5(open("test/files/test_var_replacement_for_inline_monitors.tf".format(namespace)).read()).hexdigest()
+            new = hashlib.md5(open("test_var_replacement_for_inline_monitors.tf".format(namespace)).read()).hexdigest()
+
+            logging.debug(gold)
+            logging.debug(new)
+
+            self.assertEqual(gold, new)
+
     def tearDown(self):
         os.remove("test_pods_are_stuck_pending.tf")
         os.remove("test_increase_in_network_errors.tf")
+        os.remove("test_var_replacement_for_inline_monitors.tf")
         for namespace in self.deploy_replica_alert_namespaces:
             os.remove("test_deployment_replica_alert_{}.tf".format(namespace))
 

--- a/test/files/test_input.yml
+++ b/test/files/test_input.yml
@@ -14,6 +14,26 @@ monitors:
   - source: kubernetes.deploy_replica_alert
     definitions:
       namespace: ['one','two','three']
+  - notify_audit: false
+    locked: false
+    name: 'test var replacement for inline monitors'
+    tags: [network, '${environment}', reactiveops]
+    include_tags: false
+    no_data_timeframe: null
+    silenced: {}
+    new_host_delay: 300
+    require_full_window: true
+    notify_no_data: false
+    renotify_interval: 0
+    escalation_message: ''
+    query: ${cluster} ${namespace} ${environment}
+    message: |
+      ${notifications}
+    type: metric alert
+    thresholds: {critical: 10, warning: 5}
+    timeout_h: 0
+    definitions: 
+      notifications: in-line-notifications
 downtimes:
   - name: Test Maintenance Window
     scope: "*"

--- a/test/files/test_var_replacement_for_inline_monitors.tf
+++ b/test/files/test_var_replacement_for_inline_monitors.tf
@@ -1,0 +1,24 @@
+resource "datadog_monitor" "test_var_replacement_for_inline_monitors" {
+  # Required Arguments
+  name = "test var replacement for inline monitors"
+  type = "metric alert"
+
+  message = <<EOF
+  in-line-notifications
+
+  EOF
+
+  query = "cluster_name namespace_name test"
+
+  # Optional Arguments
+  new_host_delay = 300
+
+  thresholds {
+    critical = 10
+    warning  = 5
+  }
+
+  require_full_window = true
+  tags                = ["network", "test", "reactiveops"]
+  silenced            = {}
+}


### PR DESCRIPTION
Inline definition replacement was broken for inline monitors because of a string type check (str or unicode) that prevented replacement

fixed #63