### PR TITLE
Nb/add cluster tag definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.16.0]
+### Added
+- Added `cluster_tag` as a definition variable
+- Added default `cluster_tag` == `kubernetescluster` to existing monitors and dashboards.
+
+### Updated
+- Updated all tests to include `cluster_tag`
+
 ## [1.15.0]
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ definitions:
   environment: "production"
   cluster: "production.cluster"
   notifications: "@pagerduty"
+  cluster_tag: "kubernetescluster"
 monitors:
   - notify_audit: false
     locked: false
@@ -82,6 +83,7 @@ They are denoted by `${<name>}` in the template and are referred to as "definiti
 definitions:
   cluster: working.cluster
   environment: production
+  cluster_tag: kubernetescluster
 monitors:
   - source: kubernetes
 ```
@@ -91,22 +93,11 @@ or at an individual monitor level to override the global value.
 definitions:
   cluster: working.cluster
   environment: production
+  cluster_tag: kubernetescluster
 monitors:
   - source: kubernetes
     definitions:
       environment: staging # this will override the global value
-```
-
-You can also define a custom `cluster_tag` for targeting specific kubernetes clusters. This currently defaults to `kubernetescluster`. 
-
-```yaml
-definitions:
-  cluster: working.cluster
-  environment: production
-  cluster_tag: my_working_kubernetes_cluster
-monitors:
-  - source: kubernetes
-  ...
 ```
 
 #### Namespaced Monitors
@@ -119,6 +110,7 @@ The underlying Rodd monitor must have `vary_by_namespace: true` set. The monitor
 definitions:
   cluster: working.cluster
   environment: production
+  cluster_tag: workingcluster
 monitors:
   - source: kubernetes.deploy_replica_alert
     definitions:

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ monitors:
     timeout_h: 0
 ```
 
-#### Monitor Definitions
-Alluded to above, in each monitor there are certain fields that need to be defined; `environment`, `cluster` are two examples.
+#### Definitions
+Alluded to above, in each monitor and dashboard there are certain fields that need to be defined; `environment`, `cluster` are two examples.
+
 They are denoted by `${<name>}` in the template and are referred to as "definitions". You can define definitions at a global level.
 
 ```yaml
@@ -94,6 +95,18 @@ monitors:
   - source: kubernetes
     definitions:
       environment: staging # this will override the global value
+```
+
+You can also define a custom `cluster_tag` for targeting specific kubernetes clusters. This currently defaults to `kubernetescluster`. 
+
+```yaml
+definitions:
+  cluster: working.cluster
+  environment: production
+  cluster_tag: my_working_kubernetes_cluster
+monitors:
+  - source: kubernetes
+  ...
 ```
 
 #### Namespaced Monitors

--- a/docs/monitors.md
+++ b/docs/monitors.md
@@ -5,6 +5,7 @@
         * Required Definitions:
             * `environment`
             * `cluster`
+            * `cluster_tag`
             * `notifications`
         * Optional Definitions: n/a
 
@@ -27,12 +28,14 @@
         * Required Definitions:
             * `environment`
             * `cluster`
+            * `cluster_tag`
             * `notifications`
         * Optional Definitions: n/a
     * [Disk Throttled Write Ops](/pentagon_datadog/monitors/gcp/disk_throttled_write_ops.yml)
         * Required Definitions:
             * `environment`
             * `cluster`
+            * `cluster_tag`
             * `notifications`
         * Optional Definitions: n/a
 
@@ -169,6 +172,7 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions:
             * `cluster_bytes_received_critical_threshold`: 20000000
             * `cluster_bytes_received_warning_threshold`: 17500000
@@ -177,6 +181,7 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions:
             * `cluster_bytes_sent_critical_threshold`: 20000000
             * `cluster_bytes_sent_warning_threshold`: 17500000
@@ -185,6 +190,7 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions:
             * `cluster_cpu_usage_high_critical_threshold`: 7
             * `cluster_cpu_usage_high_warning_threshold`: 5
@@ -193,6 +199,7 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions:
             * `cluster_disk_usage_high_critical_threshold`: 90
             * `cluster_disk_usage_high_warning_threshold`: 80
@@ -203,6 +210,7 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions:
             * `cluster_memory_critical_threshold`: 0.1
             * `cluster_memory_critical_warning`: 0.15
@@ -211,6 +219,7 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions:
             * `cluster_network_errors_critical_threshold`: 10
             * `cluster_network_errors_warning_threshold`: 5
@@ -219,6 +228,7 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
             * `namespace`
         * Optional Definitions:
             * `deploy_replica_alert_critical_threshold`: 0
@@ -227,18 +237,21 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions: n/a
     * [Kubelet Health](/pentagon_datadog/monitors/kubernetes/kubelet_health.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions: n/a
     * [Kubesystem Crashes](/pentagon_datadog/monitors/kubernetes/kubesystem_crashes.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions:
             * `kubesystem_crashes_critical_threshold`: 1
     * [Node Not Ready](/pentagon_datadog/monitors/kubernetes/node_not_ready.yml)
@@ -246,6 +259,7 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions:
             * `node_not_ready_critical_threshold`: 8
             * `node_not_ready_warning_threshold` 3
@@ -255,12 +269,14 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions: n/a
     * [Pods Pending](/pentagon_datadog/monitors/kubernetes/pods_pending.yml)
         * Required Definitions:
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions:
             * `pods_pending_critical_threshold`: 1
     * [HPA Errors](/pentagon_datadog/monitors/kubernetes/hpa_failure.yml)
@@ -268,6 +284,7 @@
             * `environment`
             * `notifications`
             * `cluster`
+            * `cluster_tag`
         * Optional Definitions:
             * `hpa_failure_critical_threshold`: 200
 

--- a/pentagon_datadog/dashboards/kubernetes/resources.yml
+++ b/pentagon_datadog/dashboards/kubernetes/resources.yml
@@ -71,7 +71,17 @@ graphs:
   title: Avg of kubernetes.memory.usage over $scope by pod_name
 
 template_variables:
-- {default: '*', prefix: kubernetescluster, name: scope}
-- {default: '*', prefix: kube_namespace, name: kube_namespace}
-- {default: '*', prefix: kube_deployment, name: kube_deployment}
-- {default: '*', prefix: node, name: node}
+- default: '*'
+  prefix: ${cluster_tag}
+  name: scope
+- default: '*'
+  prefix: kube_namespace
+  name: kube_namespace
+- default: '*'
+  prefix: kube_deployment
+  name: kube_deployment
+- default: '*'
+  prefix: node
+  name: node
+definition_defaults:
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/dashboards/kubernetes/utilization.yml
+++ b/pentagon_datadog/dashboards/kubernetes/utilization.yml
@@ -58,7 +58,17 @@ graphs:
     status: done
   title: '[reactiveops] Resource Utilization Dashboard'
 template_variables:
-- {default: '*', prefix: kubernetescluster, name: scope}
-- {default: '*', prefix: kube_namespace, name: kube_namespace}
-- {default: '*', prefix: kube_deployment, name: kube_deployment}
-- {default: '*', prefix: node, name: node}
+- default: '*'
+  prefix: ${cluster_tag}
+  name: scope
+- default: '*'
+  prefix: kube_namespace
+  name: kube_namespace
+- default: '*'
+  prefix: kube_deployment
+  name: kube_deployment
+- default: '*'
+  prefix: node
+  name: node
+definition_defaults:
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/files/datadog/rodd-example.yaml
+++ b/pentagon_datadog/files/datadog/rodd-example.yaml
@@ -3,6 +3,7 @@ definitions:
     environment: prod
     notifications: '@slack @pagerduty'
     namespace: prod
+    cluster_tag: kubernetescluster
 dashboards:
   - source: kubernetes.resources
 monitors:

--- a/pentagon_datadog/monitors/aws/burst_iops.yml
+++ b/pentagon_datadog/monitors/aws/burst_iops.yml
@@ -10,7 +10,7 @@ require_full_window: false
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: min(last_1h):min:aws.ebs.burst_balance{kubernetescluster:${cluster}}
+query: min(last_1h):min:aws.ebs.burst_balance{${cluster_tag}:${cluster}}
   by {host} <= 1
 message: |
   When burst capacity reaches 0, iops will be throttled. This can result in
@@ -22,3 +22,5 @@ message: |
 type: query alert
 thresholds: {critical: 1, warning: 20, critical_recovery: 10}
 timeout_h: 0
+definition_defaults:
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/gcp/disk_throttled_read_ops.yml
+++ b/pentagon_datadog/monitors/gcp/disk_throttled_read_ops.yml
@@ -11,7 +11,7 @@ notify_no_data: false
 renotify_interval: 0
 evaluation_delay: 60
 escalation_message: ''
-query: min(last_2h):(avg:gcp.gce.instance.disk.throttled_read_ops_count{kubernetescluster:${cluster}} by {host}.rollup(avg, 300) / avg:gcp.gce.instance.disk.read_ops_count{kubernetescluster:${cluster}} by {host}.rollup(avg, 300) ) * 100 > 20
+query: min(last_2h):(avg:gcp.gce.instance.disk.throttled_read_ops_count{${cluster_tag}:${cluster}} by {host}.rollup(avg, 300) / avg:gcp.gce.instance.disk.read_ops_count{${cluster_tag}:${cluster}} by {host}.rollup(avg, 300) ) * 100 > 20
 message: |
   This metric indicates disk reads are being throttled. This can result in
     - timeouts during image pulls
@@ -22,3 +22,5 @@ message: |
 type: query alert
 thresholds: {critical: 30, warning: 20, critical_recovery: 15}
 timeout_h: 0
+definition_defaults:
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/gcp/disk_throttled_write_ops.yml
+++ b/pentagon_datadog/monitors/gcp/disk_throttled_write_ops.yml
@@ -11,7 +11,7 @@ notify_no_data: false
 renotify_interval: 0
 evaluation_delay: 60
 escalation_message: ''
-query: min(last_2h):(avg:gcp.gce.instance.disk.throttled_write_ops_count{kubernetescluster:${cluster}} by {host}.rollup(avg, 300) / avg:gcp.gce.instance.disk.write_ops_count{kubernetescluster:${cluster}} by {host}.rollup(avg, 300) ) * 100 > 20
+query: min(last_2h):(avg:gcp.gce.instance.disk.throttled_write_ops_count{${cluster_tag}:${cluster}} by {host}.rollup(avg, 300) / avg:gcp.gce.instance.disk.write_ops_count{${cluster_tag}:${cluster}} by {host}.rollup(avg, 300) ) * 100 > 20
 message: |
   This metric indicates disk writes are being throttled. This can result in
     - timeouts during image pulls
@@ -21,3 +21,5 @@ message: |
 type: query alert
 thresholds: {critical: 30, warning: 20, critical_recovery: 15}
 timeout_h: 0
+definition_defaults:
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/cluster_disk_usage_high.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_disk_usage_high.yml
@@ -10,7 +10,7 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_30m):( avg:system.disk.total{kubernetescluster:${cluster}} by {host} - avg:system.disk.free{kubernetescluster:${cluster}} by {host} ) / avg:system.disk.total{kubernetescluster:${cluster}} by {host} * 100 > ${cluster_disk_usage_high_critical_threshold}
+query: avg(last_30m):( avg:system.disk.total{${cluster_tag}:${cluster}} by {host} - avg:system.disk.free{${cluster_tag}:${cluster}} by {host} ) / avg:system.disk.total{${cluster_tag}:${cluster}} by {host} * 100 > ${cluster_disk_usage_high_critical_threshold}
 message: |
     {{#is_alert}}
     Disk Usage has been above threshold over 30 minutes on {{host.name}}
@@ -37,3 +37,4 @@ definition_defaults:
   cluster_disk_usage_high_warning_threshold: 80
   cluster_disk_usage_high_critical_recovery_threshold: 75
   cluster_disk_usage_high_warning_recovery_threshold: 85
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/cluster_memory.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_memory.yml
@@ -10,7 +10,7 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_15m):avg:system.mem.pct_usable{kubernetescluster:${cluster}} by {host} < ${cluster_memory_critical_threshold}
+query: avg(last_15m):avg:system.mem.pct_usable{${cluster_tag}:${cluster}} by {host} < ${cluster_memory_critical_threshold}
 message: |
   {{#is_alert}}
   Running out of free memory on {{host.name}}
@@ -30,3 +30,4 @@ timeout_h: 0
 definition_defaults:
   cluster_memory_critical_threshold: 0.1
   cluster_memory_critical_warning: 0.15
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/cluster_network_errors.yml
+++ b/pentagon_datadog/monitors/kubernetes/cluster_network_errors.yml
@@ -10,7 +10,7 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_15m):avg:kubernetes.network.rx_errors{kubernetescluster:${cluster}} + avg:kubernetes.network.tx_errors{kubernetescluster:${cluster}} > ${cluster_network_errors_critical_threshold}
+query: avg(last_15m):avg:kubernetes.network.rx_errors{${cluster_tag}:${cluster}} + avg:kubernetes.network.tx_errors{${cluster_tag}:${cluster}} > ${cluster_network_errors_critical_threshold}
 message: |
   {{#is_alert}}
   We are getting increasing network errors
@@ -24,3 +24,4 @@ timeout_h: 0
 definition_defaults:
   cluster_network_errors_critical_threshold: 10
   cluster_network_errors_warning_threshold: 5
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/deploy_replica_alert.yml
+++ b/pentagon_datadog/monitors/kubernetes/deploy_replica_alert.yml
@@ -11,7 +11,7 @@ notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
 vary_by_namespace: true
-query: max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:${cluster},namespace:${namespace}} by {deployment} <= ${deploy_replica_alert_critical_threshold}
+query: max(last_10m):max:kubernetes_state.deployment.replicas_available{${cluster_tag}:${cluster},namespace:${namespace}} by {deployment} <= ${deploy_replica_alert_critical_threshold}
 message: |
   {{#is_alert}}
   Available replicas is currently 0 for {{deployment.name}}
@@ -27,3 +27,4 @@ timeout_h: 0
 definition_defaults:
   deploy_replica_alert_critical_threshold: 0
   namespace: kube-system
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/high_node_io_wait_time.yml
+++ b/pentagon_datadog/monitors/kubernetes/high_node_io_wait_time.yml
@@ -10,7 +10,7 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_10m):avg:system.cpu.iowait{kubernetescluster:${cluster}${high_node_io_wait_time_additional_filters}}
+query: avg(last_10m):avg:system.cpu.iowait{${cluster_tag}:${cluster}${high_node_io_wait_time_additional_filters}}
   by {host} > ${high_node_io_wait_time_critical_threshold}
 message: |
   {{#is_alert}}
@@ -32,3 +32,4 @@ definition_defaults:
   high_node_io_wait_time_additional_filters: ""
   high_node_io_wait_time_critical_threshold: 50
   high_node_io_wait_time_warning_threshold: 30
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/hpa_failure.yml
+++ b/pentagon_datadog/monitors/kubernetes/hpa_failure.yml
@@ -9,7 +9,7 @@ require_full_window: true
 notify_no_data: false
 renotify_interval: 0
 type: event alert
-query: "events('sources:kubernetes priority:all tags:kubernetescluster:${cluster} \"unable to fetch metrics from resource metrics API:\"').by('hpa').rollup('count').last('1h') > ${hpa_failure_critical_threshold}"
+query: "events('sources:kubernetes priority:all tags:${cluster_tag}:${cluster} \"unable to fetch metrics from resource metrics API:\"').by('hpa').rollup('count').last('1h') > ${hpa_failure_critical_threshold}"
 message: |
   {{#is_alert}}
   A high number of hpa failures (> {{threshold}} ) are occurring.  Can HPAs get metrics?
@@ -20,3 +20,4 @@ message: |
   ${notifications}
 definition_defaults:
   hpa_failure_critical_threshold: 200
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/kubelet_health.yml
+++ b/pentagon_datadog/monitors/kubernetes/kubelet_health.yml
@@ -6,7 +6,7 @@ tags: ['${environment}', reactiveops]
 new_host_delay: 300
 notify_no_data: false
 renotify_interval: 0
-query: '"kubernetes.kubelet.check".over("kubernetescluster:${cluster}").by("host").last(6).count_by_status()'
+query: '"kubernetes.kubelet.check".over("${cluster_tag}:${cluster}").by("host").last(6).count_by_status()'
 message: |
   {{#is_alert}}
   Kubelet has been unhealthy for 3 consecutive checks.
@@ -18,3 +18,5 @@ message: |
 type: service check
 no_data_timeframe: 2
 timeout_h: 0
+definition_defaults:
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/node_not_ready.yml
+++ b/pentagon_datadog/monitors/kubernetes/node_not_ready.yml
@@ -8,18 +8,18 @@ silenced: {}
 new_host_delay: 900
 notify_no_data: false
 renotify_interval: 0
-query: "\"kubernetes_state.node.ready\".over(\"kubernetescluster:${cluster}\").by(\"host\").last(20).count_by_status()"
+query: "\"kubernetes_state.node.ready\".over(\"${cluster_tag}:${cluster}\").by(\"host\").last(20).count_by_status()"
 message: |
   {{#is_warning}}
   A Node is not ready!
-  Cluster: {{kubernetescluster.name}}
+  Cluster: {{${cluster_tag}.name}}
   Host: {{host.name}}
   IP: {{host.ip}}
   {{check_message}}
   {{/is_warning}}
   {{#is_alert}}
   A Node is not ready!
-  Cluster: {{kubernetescluster.name}}
+  Cluster: {{${cluster_tag}.name}}
   Host: {{host.name}}
   IP: {{host.ip}}
   {{check_message}}
@@ -27,7 +27,7 @@ message: |
   {{/is_alert}}
   {{#is_recovery}}
   Node is now ready.
-  Cluster: {{kubernetescluster.name}}
+  Cluster: {{${cluster_tag}.name}}
   Host: {{host.name}}
   IP: {{host.ip}}
   {{/is_recovery}}
@@ -40,3 +40,4 @@ definition_defaults:
   node_not_ready_critical_threshold: 20
   node_not_ready_warning_threshold: 9
   node_not_ready_ok_threshold: 2
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/ntp.yml
+++ b/pentagon_datadog/monitors/kubernetes/ntp.yml
@@ -7,10 +7,12 @@ silenced: {}
 new_host_delay: 300
 notify_no_data: false
 renotify_interval: 0
-query: '"ntp.in_sync".over("kubernetescluster:${cluster}").by("host").last(6).count_by_status()'
+query: '"ntp.in_sync".over("${cluster_tag}:${cluster}").by("host").last(6).count_by_status()'
 message: |
   Triggers if any host's clock goes out of sync with the time given by NTP.
   ${notifications}
 type: service check
 no_data_timeframe: 2
 timeout_h: 0
+definition_defaults:
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/pod_crashes.yml
+++ b/pentagon_datadog/monitors/kubernetes/pod_crashes.yml
@@ -11,7 +11,7 @@ notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
 vary_by_namespace: true
-query: avg(last_5m):avg:kubernetes_state.container.restarts{kubernetescluster:${cluster},namespace:${namespace}${pod_crashes_additional_filters}} by {pod} - hour_before(avg:kubernetes_state.container.restarts{kubernetescluster:${cluster},namespace:${namespace}${pod_crashes_additional_filters}} by {pod}) > ${pod_crashes_critical_threshold}
+query: avg(last_5m):avg:kubernetes_state.container.restarts{${cluster_tag}:${cluster},namespace:${namespace}${pod_crashes_additional_filters}} by {pod} - hour_before(avg:kubernetes_state.container.restarts{${cluster_tag}:${cluster},namespace:${namespace}${pod_crashes_additional_filters}} by {pod}) > ${pod_crashes_critical_threshold}
 message: |
   {{#is_alert}}
   {{pod.name}} has crashed repeatedly over the last hour
@@ -28,3 +28,4 @@ definition_defaults:
   pod_crashes_critical_threshold: 1
   pod_crashes_additional_filters: ''
   namespace: kube-system
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/pods_pending.yml
+++ b/pentagon_datadog/monitors/kubernetes/pods_pending.yml
@@ -10,7 +10,7 @@ notify_no_data: false
 no_data_timeframe: 0
 renotify_interval: 0
 escalation_message: ''
-query: min(last_30m):sum:kubernetes_state.pod.status_phase{kubernetescluster:${cluster},phase:running} - sum:kubernetes_state.pod.status_phase{kubernetescluster:${cluster},phase:running} + sum:kubernetes_state.pod.status_phase{kubernetescluster:${cluster},phase:pending}.fill(zero) >= ${pods_pending_critical_threshold}
+query: min(last_30m):sum:kubernetes_state.pod.status_phase{${cluster_tag}:${cluster},phase:running} - sum:kubernetes_state.pod.status_phase{${cluster_tag}:${cluster},phase:running} + sum:kubernetes_state.pod.status_phase{${cluster_tag}:${cluster},phase:pending}.fill(zero) >= ${pods_pending_critical_threshold}
 message: |
   {{#is_alert}}
   There has been at least 1 pod Pending for 30 minutes.
@@ -29,3 +29,4 @@ thresholds:
 timeout_h: 0
 definition_defaults:
   pods_pending_critical_threshold: 1
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/monitors/kubernetes/system_load_average_high.yml
+++ b/pentagon_datadog/monitors/kubernetes/system_load_average_high.yml
@@ -10,7 +10,7 @@ new_host_delay: 300
 notify_no_data: false
 renotify_interval: 0
 escalation_message: ''
-query: avg(last_30m):avg:system.load.norm.5{kubernetescluster:${cluster}${system_load_average_additional_filters}} by {host} > ${system_load_average_critical_threshold}
+query: avg(last_30m):avg:system.load.norm.5{${cluster_tag}:${cluster}${system_load_average_additional_filters}} by {host} > ${system_load_average_critical_threshold}
 message: |
   Load average is high on {{host.name}} {{host.ip}}.
   This is a normalized load based on the number of CPUs (i.e. ActualLoadAverage / NumberOfCPUs)
@@ -24,3 +24,4 @@ timeout_h: 0
 definition_defaults:
   system_load_average_critical_threshold: 2
   system_load_average_additional_filters: ""
+  cluster_tag: kubernetescluster

--- a/pentagon_datadog/rodd.py
+++ b/pentagon_datadog/rodd.py
@@ -193,6 +193,11 @@ class Rodd(ComponentBase):
                 logging.debug("Found thresholds: {}".format(data[key]))
                 for threshold_type in data[key]:
                     data[key][threshold_type] = _replace_definition(data[key][threshold_type], _definitions)
+            elif key == 'template_variables':
+                logging.debug("Found template_variables: {}".format(data[key]))
+                for index, item in enumerate(data[key]):
+                    for k, v in item.iteritems():
+                        data[key][index][k] = _replace_definition(v, _definitions)
             else:
                 data[key] = _replace_definition(data[key], _definitions)
         return data

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
     sys.exit(1)
 
 setup(name='pentagon_datadog',
-      version='1.15.0',
+      version='1.16.0',
       description='Pentagon Component to install common datadog monitors',
       author='ReactiveOp Inc.',
       author_email='reactive@reactiveops.com',

--- a/test/files/reactiveops_kubernetes_resource_timeboard.tf
+++ b/test/files/reactiveops_kubernetes_resource_timeboard.tf
@@ -92,7 +92,7 @@ resource "datadog_timeboard" "reactiveops_kubernetes_resource_timeboard" {
   template_variable {
     default = "*"
     name    = "scope"
-    prefix  = "kubernetescluster"
+    prefix  = "cluster_tag"
   }
 
   template_variable {

--- a/test/files/test_deployment_replica_alert_one.tf
+++ b/test/files/test_deployment_replica_alert_one.tf
@@ -14,7 +14,7 @@ ${notifications}
 
   EOF
 
-  query = "max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:cluster_name,namespace:one} by {deployment} <= 0"
+  query = "max(last_10m):max:kubernetes_state.deployment.replicas_available{cluster_tag:cluster_name,namespace:one} by {deployment} <= 0"
 
   # Optional Arguments
   new_host_delay = 300

--- a/test/files/test_deployment_replica_alert_three.tf
+++ b/test/files/test_deployment_replica_alert_three.tf
@@ -14,7 +14,7 @@ ${notifications}
 
   EOF
 
-  query = "max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:cluster_name,namespace:three} by {deployment} <= 0"
+  query = "max(last_10m):max:kubernetes_state.deployment.replicas_available{cluster_tag:cluster_name,namespace:three} by {deployment} <= 0"
 
   # Optional Arguments
   new_host_delay = 300

--- a/test/files/test_deployment_replica_alert_two.tf
+++ b/test/files/test_deployment_replica_alert_two.tf
@@ -14,7 +14,7 @@ ${notifications}
 
   EOF
 
-  query = "max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:cluster_name,namespace:two} by {deployment} <= 0"
+  query = "max(last_10m):max:kubernetes_state.deployment.replicas_available{cluster_tag:cluster_name,namespace:two} by {deployment} <= 0"
 
   # Optional Arguments
   new_host_delay = 300

--- a/test/files/test_increase_in_network_errors.tf
+++ b/test/files/test_increase_in_network_errors.tf
@@ -11,7 +11,7 @@ ${notifications}
 
   EOF
 
-  query = "avg(last_15m):avg:kubernetes.network.rx_errors{kubernetescluster:cluster_name} + avg:kubernetes.network.tx_errors{kubernetescluster:cluster_name} > 10"
+  query = "avg(last_15m):avg:kubernetes.network.rx_errors{cluster_tag:cluster_name} + avg:kubernetes.network.tx_errors{cluster_tag:cluster_name} > 10"
 
   # Optional Arguments
   new_host_delay = 300

--- a/test/files/test_input.yml
+++ b/test/files/test_input.yml
@@ -3,6 +3,7 @@ definitions:
   cluster: cluster_name
   namespace: namespace_name
   environment: test
+  cluster_tag: cluster_tag
 dashboards:
   - source: kubernetes.resources
 monitors:

--- a/test/files/test_pods_are_stuck_pending.tf
+++ b/test/files/test_pods_are_stuck_pending.tf
@@ -18,7 +18,7 @@ ${notifications}
 
   EOF
 
-  query = "min(last_30m):sum:kubernetes_state.pod.status_phase{kubernetescluster:cluster_name,phase:running} - sum:kubernetes_state.pod.status_phase{kubernetescluster:cluster_name,phase:running} + sum:kubernetes_state.pod.status_phase{kubernetescluster:cluster_name,phase:pending}.fill(zero) >= 1"
+  query = "min(last_30m):sum:kubernetes_state.pod.status_phase{cluster_tag:cluster_name,phase:running} - sum:kubernetes_state.pod.status_phase{cluster_tag:cluster_name,phase:running} + sum:kubernetes_state.pod.status_phase{cluster_tag:cluster_name,phase:pending}.fill(zero) >= 1"
 
   # Optional Arguments
   new_host_delay = 300

--- a/test/files/test_pods_are_stuck_pending_def_global.tf
+++ b/test/files/test_pods_are_stuck_pending_def_global.tf
@@ -18,7 +18,7 @@ ${notifications}
 
   EOF
 
-  query = "min(last_30m):sum:kubernetes_state.pod.status_phase{kubernetescluster:cluster_name,phase:running} - sum:kubernetes_state.pod.status_phase{kubernetescluster:cluster_name,phase:running} + sum:kubernetes_state.pod.status_phase{kubernetescluster:cluster_name,phase:pending}.fill(zero) >= 1234"
+  query = "min(last_30m):sum:kubernetes_state.pod.status_phase{cluster_tag:cluster_name,phase:running} - sum:kubernetes_state.pod.status_phase{cluster_tag:cluster_name,phase:running} + sum:kubernetes_state.pod.status_phase{cluster_tag:cluster_name,phase:pending}.fill(zero) >= 1234"
 
   # Optional Arguments
   new_host_delay = 300


### PR DESCRIPTION
This PR adds the ability to configure a definition for setting `cluster_tag`. This currently defaults to `kubernetescluster`. The goal is to make RODD more flexible when creating monitors/dashboards for clusters that have not been provisioned using KOPS.